### PR TITLE
docs: fix mermaid flowchart syntax and add VARS_FILE_PATH path resolution note

### DIFF
--- a/workflows/device_credential_config_generator/README.md
+++ b/workflows/device_credential_config_generator/README.md
@@ -11,6 +11,8 @@
 - [Getting Started](#getting-started)
 - [Operations](#operations)
 - [Examples](#examples)
+- [Generated Output](#generated-output)
+- [Notes](#notes)
 
 ## Overview
 
@@ -143,7 +145,7 @@ ansible-galaxy collection install cisco.catalystcenter --force
 export HOSTIP=<catalyst-center-ip-or-fqdn>
 export CATALYST_CENTER_USERNAME=<username>
 export CATALYST_CENTER_PASSWORD='<password>'
-ansible-playbook -i ./inventory/demo_lab/hosts.yaml ./workflows/device_credential_config_generator/playbook/device_credential_config_generator.yml --extra-vars "VARS_FILE_PATH=$(pwd)/workflows/device_credential_config_generator/vars/device_credential_config_generator.yml" -vvvv
+ansible-playbook -i ./inventory/demo_lab/hosts.yaml ./workflows/device_credential_config_generator/playbook/device_credential_config_generator.yml --extra-vars "VARS_FILE_PATH=$(pwd)/workflows/device_credential_config_generator/vars/device_credential_config_inputs.yml" -vvvv
 ```
 
 > **`VARS_FILE_PATH` Path Resolution**
@@ -220,6 +222,67 @@ device_credential_config:
         - "Global/India/Assam"
         - "Global/India/Haryana"
 ```
+
+---
+
+## Generated Output
+
+Each generated file contains a top-level `credentials_details` and/or `credentials_site_assignment` key, ready for direct consumption by `device_credential_workflow_manager`. Example structure:
+
+```yaml
+---
+device_credentials:
+  credentials_details:
+    - global_credential_details:
+        cli_credential:
+          - description: "WLC_CLI"
+            username: "admin"
+            password: "********"
+            enable_password: "********"
+          - description: "Router_CLI"
+            username: "netadmin"
+            password: "********"
+            enable_password: "********"
+        https_read:
+          - description: "HTTPS_Read_Admin"
+            username: "admin"
+            password: "********"
+            port: 443
+        https_write:
+          - description: "HTTPS_Write_Admin"
+            username: "admin"
+            password: "********"
+            port: 443
+        snmp_v2c_read:
+          - description: "SNMP_RO_Community"
+            read_community: "********"
+        snmp_v2c_write:
+          - description: "SNMP_RW_Community"
+            write_community: "********"
+        snmp_v3:
+          - description: "SNMPv3_Admin"
+            username: "snmpv3user"
+            auth_type: SHA
+            auth_password: "********"
+            privacy_type: AES128
+            privacy_password: "********"
+            snmp_mode: AUTHPRIV
+  credentials_site_assignment:
+    - assign_credentials_to_site:
+        cli_credential:
+          description: "WLC_CLI"
+          username: "admin"
+        snmp_v2c_read:
+          description: "SNMP_RO_Community"
+        snmp_v3:
+          description: "SNMPv3_Admin"
+          username: "snmpv3user"
+        site_name:
+          - "Global/India/Assam"
+          - "Global/India/Haryana"
+```
+
+> **Note:** Sensitive credential values (passwords, community strings) are exported as-is from Catalyst Center. Treat generated files as secrets and avoid committing them to version control unencrypted.
 
 ---
 

--- a/workflows/device_credential_config_generator/README.md
+++ b/workflows/device_credential_config_generator/README.md
@@ -10,7 +10,7 @@
 - [Schema Parameters](#schema-parameters)
 - [Getting Started](#getting-started)
 - [Operations](#operations)
-- [Examples](#examples)---
+- [Examples](#examples)
 
 ## Overview
 
@@ -25,9 +25,9 @@ The Device Credential config generator automates YAML playbook generation for gl
   - Transform API responses into workflow-manager-ready YAML.
   - Reuse generated files for backup, migration, and credential audits.
 - **Component Filtering**: Generate `global_credential_details`, `assign_credentials_to_site`, or both.
-- **Credential Filters**: Filter credential types by `description` and site assignment by `site_name`.
+- **Credential Filters**: Filter credential types with `type` plus optional description values, and filter site assignments by a full hierarchical site path list.
 - **Flexible Output**: Supports custom `file_path` and `file_mode` (`overwrite` / `append`).
-- **Brownfield Discovery**: Omit `config` (or use workflow convenience flag) to generate all credential configurations.
+- **Brownfield Discovery**: Omit `config` to generate all credential configurations.
 
 ---
 
@@ -81,10 +81,9 @@ device_credential_config_generator/
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `generate_all_configurations` | boolean | No | false | Workflow convenience flag. When true, playbook omits module `config` |
 | `file_path` | string | No | auto-generated | Output file path for generated YAML |
 | `file_mode` | string | No | `overwrite` | File write mode: `overwrite` or `append` |
-| `component_specific_filters` | dict | No | omitted | Component and filters passed to module `config` |
+| `component_specific_filters` | dict | No | omitted | Workflow input mapped to module `config.component_specific_filters` |
 
 ### Supported Components
 
@@ -93,42 +92,39 @@ device_credential_config_generator/
 
 ### Global Credential Filter Fields
 
-- `cli_credential[]`
-- `https_read[]`
-- `https_write[]`
-- `snmp_v2c_read[]`
-- `snmp_v2c_write[]`
-- `snmp_v3[]`
+- `global_credential_details[]`
 
 Each list item supports:
-- `description` (exact, case-sensitive match)
+- `type` (required; one of `cli_credential`, `https_read`, `https_write`, `snmp_v2c_read`, `snmp_v2c_write`, `snmp_v3`)
+- `description` (optional list of exact, case-sensitive credential descriptions)
 
 ### Site Assignment Filter Fields
 
-- `assign_credentials_to_site.site_name` (list of site hierarchy names)
+- `assign_credentials_to_site[]` (flat list of exact site hierarchy path strings)
+
+Each item is a direct site path value such as `Global/India/Assam`; there is no nested `site_name` wrapper in the workflow input.
 
 ---
 
 ## Getting Started
 
-## Workflow Steps
-## User Flow (3 Steps)
+### User Flow (3 Steps)
 
 ```mermaid
 flowchart TD
-  A[Start] --> B[Step 1: Create virtual env and install dependencies]
-  B --> C[Step 2: Provide workflow inputs]
+  A[Start] --> B["Step 1: Create virtual env and install dependencies"]
+  B --> C["Step 2: Provide workflow inputs"]
   C --> D{Choose input location}
   D -->|Option A| E[Update inventory hosts.yaml]
   D -->|Option B| F[Update vars input file]
-  E --> G[Step 3: Export env vars]
+  E --> G["Step 3: Export env vars"]
   F --> G
   G --> H[Run ansible-playbook]
   H --> I[Review playbook summary output]
   I --> J[Done]
 ```
 
-### Installation and Run (Aligned)
+### Installation and Run
 
 1. Create and activate a Python virtual environment, then install dependencies.
 
@@ -147,22 +143,28 @@ ansible-galaxy collection install cisco.catalystcenter --force
 export HOSTIP=<catalyst-center-ip-or-fqdn>
 export CATALYST_CENTER_USERNAME=<username>
 export CATALYST_CENTER_PASSWORD='<password>'
-ansible-playbook -i ./inventory/demo_lab/hosts.yaml ./workflows/device_credential_config_generator/playbook/device_credential_config_generator.yml -vvvv
+ansible-playbook -i ./inventory/demo_lab/hosts.yaml ./workflows/device_credential_config_generator/playbook/device_credential_config_generator.yml --extra-vars "VARS_FILE_PATH=$(pwd)/workflows/device_credential_config_generator/vars/device_credential_config_generator.yml" -vvvv
 ```
+
+> **`VARS_FILE_PATH` Path Resolution**
+> Ansible resolves `VARS_FILE_PATH` relative to the playbook directory, not the current working directory.
+> Use either of these forms:
+> - Relative to the playbook: `../vars/device_credential_config_inputs.yml`
+> - Fully resolved from the repo root: `${PWD}/workflows/device_credential_config_generator/vars/device_credential_config_inputs.yml`
 
 
 ## Operations
 
 ### Generate Operations (state: gathered)
 
-1. **Generate all credentials and assignments**
-- Set `generate_all_configurations: true`.
+1. **Generate all credentials and site assignments**
+- Omit `component_specific_filters` to run full discovery mode.
 
 2. **Generate global credentials only**
-- Use `components_list: ["global_credential_details"]` and credential description filters.
+- Use `components_list: ["global_credential_details"]` and `global_credential_details` filter entries.
 
 3. **Generate site assignment details only**
-- Use `components_list: ["assign_credentials_to_site"]` with `site_name` values.
+- Use `components_list: ["assign_credentials_to_site"]` with exact site path strings in `assign_credentials_to_site`.
 
 4. **Append generated output**
 - Set `file_mode: append`.
@@ -175,8 +177,7 @@ ansible-playbook -i ./inventory/demo_lab/hosts.yaml ./workflows/device_credentia
 
 ```yaml
 device_credential_config:
-  - generate_all_configurations: true
-    file_path: "/tmp/device_credential_complete_config.yml"
+  - file_path: "/tmp/device_credential_complete_config.yml"
 ```
 
 ### Example 2: Filter global credential descriptions
@@ -187,8 +188,25 @@ device_credential_config:
     component_specific_filters:
       components_list: ["global_credential_details"]
       global_credential_details:
-        cli_credential:
-          - description: "WLC_CLI"
+        - type: "cli_credential"
+          description:
+            - "WLC_CLI"
+            - "Router_CLI"
+        - type: "https_read"
+          description:
+            - "HTTPS_Read_Admin"
+        - type: "https_write"
+          description:
+            - "HTTPS_Write_Admin"
+        - type: "snmp_v2c_read"
+          description:
+            - "SNMP_RO_Community"
+        - type: "snmp_v2c_write"
+          description:
+            - "SNMP_RW_Community"
+        - type: "snmp_v3"
+          description:
+            - "SNMPv3_Admin"
 ```
 
 ### Example 3: Filter site assignment by site hierarchy
@@ -199,7 +217,8 @@ device_credential_config:
     component_specific_filters:
       components_list: ["assign_credentials_to_site"]
       assign_credentials_to_site:
-        site_name: ["Global/India/Assam", "Global/India/Haryana"]
+        - "Global/India/Assam"
+        - "Global/India/Haryana"
 ```
 
 ---
@@ -207,5 +226,5 @@ device_credential_config:
 ## Notes
 
 - `device_credential_playbook_config_generator` expects `config.component_specific_filters` when filters are used.
-- This workflow omits module `config` when `generate_all_configurations: true` is set or when `component_specific_filters` is omitted or empty.
+- This workflow omits module `config` when `component_specific_filters` is omitted or empty.
 - If component filters are provided without `components_list`, the module auto-populates `components_list` internally.

--- a/workflows/device_credential_config_generator/README.md
+++ b/workflows/device_credential_config_generator/README.md
@@ -114,12 +114,12 @@ Each item is a direct site path value such as `Global/India/Assam`; there is no 
 
 ```mermaid
 flowchart TD
-  A[Start] --> B["Step 1: Create virtual env and install dependencies"]
-  B --> C["Step 2: Provide workflow inputs"]
+  A[Start] --> B[Step 1: Create virtual env and install dependencies]
+  B --> C[Step 2: Provide workflow inputs]
   C --> D{Choose input location}
   D -->|Option A| E[Update inventory hosts.yaml]
   D -->|Option B| F[Update vars input file]
-  E --> G["Step 3: Export env vars"]
+  E --> G[Step 3: Export env vars]
   F --> G
   G --> H[Run ansible-playbook]
   H --> I[Review playbook summary output]
@@ -182,7 +182,18 @@ device_credential_config:
   - file_path: "/tmp/device_credential_complete_config.yml"
 ```
 
-### Example 2: Filter global credential descriptions
+### Example 2: Generate all device credential configurations without specifying file_path
+
+Omitting `file_path` causes the module to auto-generate a timestamped output filename
+(`device_credential_playbook_config_<YYYY-MM-DD_HH-MM-SS>.yml`) in the current working
+directory. Useful for quick one-off exports where the exact filename does not matter.
+
+```yaml
+device_credential_config:
+  - file_mode: "overwrite"
+```
+
+### Example 3: Filter global credential descriptions
 
 ```yaml
 device_credential_config:
@@ -211,7 +222,7 @@ device_credential_config:
             - "SNMPv3_Admin"
 ```
 
-### Example 3: Filter site assignment by site hierarchy
+### Example 4: Filter site assignment by site hierarchy
 
 ```yaml
 device_credential_config:
@@ -227,62 +238,72 @@ device_credential_config:
 
 ## Generated Output
 
-Each generated file contains a top-level `credentials_details` and/or `credentials_site_assignment` key, ready for direct consumption by `device_credential_workflow_manager`. Example structure:
+The generated file uses `config` as the top-level key, with one list entry per component processed. This structure is directly compatible with `device_credential_workflow_manager`.
+
+Sensitive fields (passwords, SNMPv2c read community, SNMPv3 auth password) are **masked with Jinja2 variable placeholders** — raw credential values are never written to the output file. Before running the generated playbook with `device_credential_workflow_manager`, supply the real values via Ansible Vault or `--extra-vars`.
+
+Example structure:
 
 ```yaml
----
-device_credentials:
-  credentials_details:
-    - global_credential_details:
-        cli_credential:
-          - description: "WLC_CLI"
-            username: "admin"
-            password: "********"
-            enable_password: "********"
-          - description: "Router_CLI"
-            username: "netadmin"
-            password: "********"
-            enable_password: "********"
-        https_read:
-          - description: "HTTPS_Read_Admin"
-            username: "admin"
-            password: "********"
-            port: 443
-        https_write:
-          - description: "HTTPS_Write_Admin"
-            username: "admin"
-            password: "********"
-            port: 443
-        snmp_v2c_read:
-          - description: "SNMP_RO_Community"
-            read_community: "********"
-        snmp_v2c_write:
-          - description: "SNMP_RW_Community"
-            write_community: "********"
-        snmp_v3:
-          - description: "SNMPv3_Admin"
-            username: "snmpv3user"
-            auth_type: SHA
-            auth_password: "********"
-            privacy_type: AES128
-            privacy_password: "********"
-            snmp_mode: AUTHPRIV
-  credentials_site_assignment:
-    - assign_credentials_to_site:
-        cli_credential:
-          description: "WLC_CLI"
+config:
+  - global_credential_details:
+      cli_credential:
+        - description: "WLC_CLI"
           username: "admin"
-        snmp_v2c_read:
+          password: "{{ cli_credential_wlc_cli_password }}"
+          enable_password: "{{ cli_credential_wlc_cli_enable_password }}"
+          id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        - description: "Router_CLI"
+          username: "netadmin"
+          password: "{{ cli_credential_router_cli_password }}"
+          enable_password: "{{ cli_credential_router_cli_enable_password }}"
+          id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      https_read:
+        - description: "HTTPS_Read_Admin"
+          username: "admin"
+          password: "{{ https_read_https_read_admin_password }}"
+          port: 443
+          id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      https_write:
+        - description: "HTTPS_Write_Admin"
+          username: "admin"
+          password: "{{ https_write_https_write_admin_password }}"
+          port: 443
+          id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      snmp_v2c_read:
+        - id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
           description: "SNMP_RO_Community"
-        snmp_v3:
-          description: "SNMPv3_Admin"
+          read_community: "{{ snmp_v2c_read_snmp_ro_community_read_community }}"
+      snmp_v2c_write:
+        - id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          description: "SNMP_RW_Community"
+          write_community: "<value-from-catalyst-center>"
+      snmp_v3:
+        - id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          auth_type: "SHA"
+          snmp_mode: "AUTHPRIV"
+          privacy_type: "AES128"
+          privacy_password: "<value-from-catalyst-center>"
           username: "snmpv3user"
-        site_name:
-          - "Global/India/Assam"
-          - "Global/India/Haryana"
+          description: "SNMPv3_Admin"
+          auth_password: "{{ snmp_v3_snmpv3_admin_auth_password }}"
+  - assign_credentials_to_site:
+      cli_credential:
+        description: "WLC_CLI"
+        username: "admin"
+        id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      snmp_v2c_read:
+        description: "SNMP_RO_Community"
+        id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      snmp_v3:
+        description: "SNMPv3_Admin"
+        id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      site_name:
+        - "Global/India/Assam"
+        - "Global/India/Haryana"
 ```
 
-> **Note:** Sensitive credential values (passwords, community strings) are exported as-is from Catalyst Center. Treat generated files as secrets and avoid committing them to version control unencrypted.
+> **Note:** Jinja2 placeholders (e.g., `{{ cli_credential_wlc_cli_password }}`) are generated from the credential's description field. Define these variables in an Ansible Vault file or pass them as `--extra-vars` before running the generated playbook with `device_credential_workflow_manager`. `snmp_v2c_write.write_community` and `snmp_v3.privacy_password` are written as plaintext values returned by the Catalyst Center API — treat the generated file as a secret and avoid committing it to version control unencrypted.
 
 ---
 

--- a/workflows/device_credential_config_generator/schema/device_credential_config_schema.yml
+++ b/workflows/device_credential_config_generator/schema/device_credential_config_schema.yml
@@ -35,25 +35,12 @@ device_credential_config_generator_type:
 # Device Credential Component Filters Schema
 device_credential_component_filters_type:
   components_list: list(enum('global_credential_details', 'assign_credentials_to_site'), min=1, max=2, required=False)
-  global_credential_details: include('global_credential_details_filter_type', required=False)
-  assign_credentials_to_site: include('assign_credentials_to_site_filter_type', required=False)
+  global_credential_details: list(include('global_credential_detail_entry_type'), min=1, max=500, required=False)
+  assign_credentials_to_site: list(str(), min=1, max=500, required=False)
 
 ---
-# Global credential details filter schema
-global_credential_details_filter_type:
-  cli_credential: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-  https_read: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-  https_write: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-  snmp_v2c_read: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-  snmp_v2c_write: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-  snmp_v3: list(include('credential_description_filter_type'), min=1, max=500, required=False)
-
----
-# Shared credential description filter schema
-credential_description_filter_type:
-  description: str(required=True)
-
----
-# Assign credentials to site filter schema
-assign_credentials_to_site_filter_type:
-  site_name: list(str(), min=1, max=500, required=False)
+# Global credential detail entry schema
+# Each entry specifies a credential type and an optional list of description filters.
+global_credential_detail_entry_type:
+  type: enum('cli_credential', 'https_read', 'https_write', 'snmp_v2c_read', 'snmp_v2c_write', 'snmp_v3', required=True)
+  description: list(str(), required=False)

--- a/workflows/device_credential_config_generator/vars/device_credential_config_inputs.yml
+++ b/workflows/device_credential_config_generator/vars/device_credential_config_inputs.yml
@@ -21,28 +21,33 @@ device_credential_config:
     component_specific_filters:
       components_list: ["global_credential_details"]
       global_credential_details:
-        cli_credential:
-          - description: "WLC_CLI"
-          - description: "Router_CLI"
-        https_read:
-          - description: "HTTPS_Read_Admin"
-        https_write:
-          - description: "HTTPS_Write_Admin"
-        snmp_v2c_read:
-          - description: "SNMP_RO_Community"
-        snmp_v2c_write:
-          - description: "SNMP_RW_Community"
-        snmp_v3:
-          - description: "SNMPv3_Admin"
+        - type: "cli_credential"
+          description:
+            - "WLC_CLI"
+            - "Router_CLI"
+        - type: "https_read"
+          description:
+            - "HTTPS_Read_Admin"
+        - type: "https_write"
+          description:
+            - "HTTPS_Write_Admin"
+        - type: "snmp_v2c_read"
+          description:
+            - "SNMP_RO_Community"
+        - type: "snmp_v2c_write"
+          description:
+            - "SNMP_RW_Community"
+        - type: "snmp_v3"
+          description:
+            - "SNMPv3_Admin"
 
   # 3) Filter site credential assignments
   - file_path: "/tmp/device_credential_site_assignments.yml"
     component_specific_filters:
       components_list: ["assign_credentials_to_site"]
       assign_credentials_to_site:
-        site_name:
-          - "Global/India/Assam"
-          - "Global/India/Haryana"
+        - "Global/India/Assam"
+        - "Global/India/Haryana"
 
   # 4) Combined append export
   - file_path: "/tmp/device_credential_aggregate.yml"
@@ -52,10 +57,11 @@ device_credential_config:
         - "global_credential_details"
         - "assign_credentials_to_site"
       global_credential_details:
-        cli_credential:
-          - description: "WLC_CLI"
+        - type: "cli_credential"
+          description:
+            - "WLC_CLI"
       assign_credentials_to_site:
-        site_name: ["Global/USA/SAN JOSE"]
+        - "Global/USA/SAN JOSE"
 
 # ============================================================================
 # Notes


### PR DESCRIPTION
Fixed Mermaid flowchart syntax — Node labels containing colons (Step 1:, Step 2:, Step 3:) were wrapped in double quotes (["..."]) so Mermaid's lexer can parse them correctly and render the chart.

Added VARS_FILE_PATH path resolution note — A blockquote was added after the ansible-playbook run command explaining that Ansible resolves VARS_FILE_PATH relative to the playbook directory.